### PR TITLE
Drop 1.19, 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
       - functional-test:
           matrix:
             parameters:
-              kube_version: ["1.19.16", "1.20.15", "1.21.14", "1.22.15", "1.23.12", "1.24.6", "1.25.2"]
+              kube_version: ["1.21.14", "1.22.15", "1.23.12", "1.24.6", "1.25.2"]
           requires:
             - build
       - scan-trivy:


### PR DESCRIPTION
Related to https://github.com/astronomer/issues/issues/5177, we are dropping 1.19 and 1.20 because they are deprecated by all major cloud providers.