### PR TITLE
Fix SQLite vulnerability CVE-2023-7104 in certgenerator Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN uv build
 FROM python:3.11.13-alpine3.22
 
 # upgrade apk packages
-RUN apk upgrade
+RUN apk upgrade && apk add --upgrade sqlite-libs
 
 # Upgrade pip
 


### PR DESCRIPTION
## Description
Security scan identified SQLite vulnerability CVE-2023-7104 in the Alpine Linux base image. The vulnerable SQLite version (3.49.2-r0) could lead to memory corruption issues when the number of aggregate terms exceeds available columns.

## Related
https://github.com/astronomer/security-issues/issues/4093